### PR TITLE
Clarify knowledge base guidelines in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,12 @@
   so paths remain consistent with the HTML originals.
 - Some folders (e.g., `CVS`) are historical artifacts and can be ignored unless
   needed.
+- The Markdown files in `md/` are the canonical source for project knowledge.
+  Use them when answering questions or drafting documentation.
+- Treat everything under `udanax/` as read-only; the HTML files and other
+  resources are preserved solely for reference.
+- Smalltalk source files in `udanax/gold/download/` are provided for historical
+  context. There is no active environment to run them, so they generally do not
+  need modification.
+- When researching the repository, search within `md/` using `grep` or `find`
+  to locate relevant information quickly.


### PR DESCRIPTION
## Summary
- instruct that Markdown files under `md` are the canonical source of project knowledge
- mark the `udanax` folder and HTML files as read-only reference
- note that included Smalltalk source is for historical context
- add tips for searching the Markdown when answering questions

## Testing
- `pytest -q`