### PR TITLE
Fix anchor link checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "fmt": "prettier --write '**/*.md'",
     "fmt:check": "prettier '**/*.md' --check",
     "links": "linkinator '**/*.md' --markdown --skip '(https?:|mailto:|tel:)' --skip '/node_modules/'",
-    "anchors": "markdownlint-cli2 '**/*.md'",
+    "anchors": "node scripts/check-anchors.js",
     "ok": "npm run fmt:check && npm run links && npm run anchors"
   },
   "dependencies": {

--- a/scripts/check-anchors.js
+++ b/scripts/check-anchors.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(text) {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[\s]+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '');
+}
+
+function getMarkdownFiles(dir) {
+  let results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue;
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(getMarkdownFiles(res));
+    } else if (entry.isFile() && res.endsWith('.md')) {
+      results.push(res);
+    }
+  }
+  return results;
+}
+
+function checkFile(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const headingSlugRegex = /^#+\s*(.+)$/gm;
+  const anchors = new Set();
+  let match;
+  while ((match = headingSlugRegex.exec(content))) {
+    anchors.add(slugify(match[1]));
+  }
+  const linkRegex = /\[[^\]]*\]\(#([^\)]+)\)/g;
+  const missing = [];
+  while ((match = linkRegex.exec(content))) {
+    const target = match[1];
+    if (!anchors.has(target)) {
+      missing.push(target);
+    }
+  }
+  if (missing.length) {
+    console.error(`Missing anchors in ${file}:`, missing.join(', '));
+    return false;
+  }
+  return true;
+}
+
+let ok = true;
+for (const file of getMarkdownFiles(process.cwd())) {
+  ok &= checkFile(file);
+}
+if (!ok) {
+  console.error('Anchor check failed');
+  process.exit(1);
+}

--- a/specs/dictionary.md
+++ b/specs/dictionary.md
@@ -8,7 +8,7 @@ users' [documents](#document). Users can have multiple accounts.
 
 ## Be
 
-Short for [backend](#backends). ([source](green/febe/glossary.html))
+Short for [backend](#backend). ([source](green/febe/glossary.html))
 
 ## backend
 


### PR DESCRIPTION
## Summary
- add a script to verify anchor links
- fix a broken anchor in the dictionary
- run the new check from `npm run anchors`

## Testing
- `node scripts/check-anchors.js`
- `npm run ok` *(fails: linkinator not found)*