### PR TITLE
Convert external docs to Markdown

### DIFF
--- a/md/FAQ.md
+++ b/md/FAQ.md
@@ -1,23 +1,621 @@
-FAQ (Frequently Asked Questions)
+# ![](http://www.xanadu.com.au/images/xlogo.gif)Xanadu FAQ
 
-[![](images/logo.gif)](index.html)
+This document contains information about the Xanadu Project which may be
+of interest to the general public and readers of the
+[xanews](mailto:xanews-request@xanadu.com.au) mailing list.
+It is currently maintained by
+[xanni@xanadu.com.au (Andrew Pam)](mailto:xanni@xanadu.com.au)
+of Xanadu Australia and posted approximately monthly.
 
-\*\*FAQ
+This document is copyright (c) 1994-2002 Xanadu Australia and may be freely
+distributed in any media providing it is not modified in any way and no
+fee is charged either for this document or for any composite work in
+which it is included.
 
-Frequently Asked Questions\*\*
+This FAQ and other Xanadu information are also available at
+[http://www.xanadu.com.au/](http://www.xanadu.com.au/).
+
+Questions in this document are numbered, and answers are labelled
+with letters of the alphabet. Thus 1 is the first question, and
+1a is the first answer to the first question. Suggestions for
+additions, corrections and expansion of the material in this
+document are welcomed.
+
+## Contents
+
+- What is Xanadu?
+
+- What requirements do Xanadu systems aim to meet?
+
+- What software meets some of the Xanadu requirements?
+
+- What is the history of the Xanadu system?
+
+- How can I contact Project Xanadu?
+
+- What Xanadu-related merchandise is currently available?
+
+- What is the history of the name "Xanadu"?
 
 ---
 
-\*\*\*to be written
+## 1 What is Xanadu?
+
+### 1a
+
+Xanadu is a trade and service mark of Project Xanadu for computer
+software and services for electronic publishing and media manipulation.
+See question 5 below for Project Xanadu contact details.
+
+### 1b
+
+Xanadu is the original hypertext and interactive multimedia system,
+under continuous development since 1960. See question 4
+below for the history of the Xanadu system.
+
+### 1c
+
+Xanadu is an overall paradigm - an ideal and general model for all
+computer use, based on sideways connections among documents and files.
+This paradigm is especially concerned with electronic publishing, but
+also extends to all forms of storing, presenting and working with
+information. It is a unifying system of order for all information,
+non-hierarchical and side-linking, including electronic publishing,
+personal work, organisation of files, corporate work and groupware.
+
+All data (for instance, paragraphs of a text document) may be connected
+sideways and out of sequence to other data (for instance, paragraphs of
+another text document). This requires new forms of storage, and invites
+new forms of presentation to show these connections.
+
+On a small scale, the paradigm means a model of word processing where
+comments, outlines and other notes may be stored conceptually adjacent
+to a document, linked to it sideways. On a large scale, the paradigm
+means a model of publishing where anyone may quote from and publish
+links to any already-published document, and any reader may follow these
+links to and from the document.
+
+### 1d
+
+Xanadu is an ideal of open electronic publishing based on the paradigm
+mentioned in answer 1c above. It is intended to be
+especially free and fair, where all authors and readers are considered
+equal. It is a complete business system for electronic publishing based
+on this ideal with a win-win set of arrangements, contracts and software
+for the sale of copyrighted material in large and small amounts. It is
+a planned world-wide publishing network based on this business system.
+It is optimised for a point-and-click universe, where users jump from
+document to document, following links and buying small pieces as they
+go.
+
+### 1e
+
+The Xanadu Australia formal problem definition is:
+
+We need a way for people to store information not as individual "files"
+but as a connected literature. It must be possible to create, access
+and manipulate this literature of richly formatted and connected
+information cheaply, reliably and securely from anywhere in the world.
+Documents must remain accessible indefinitely, safe from any kind of
+loss, damage, modification, censorship or removal except by the owner.
+It must be impossible to falsify ownership or track individual readers
+of any document.
+
+This system of literature (the "Xanadu Docuverse") must allow people to
+create virtual copies ("transclusions") of any existing collection of
+information in the system **regardless of ownership**. In order to
+make this possible, the system must guarantee that the owner of any
+information will be paid their chosen royalties on any portions of their
+documents, no matter how small, whenever and wherever they are used.
 
 ---
 
-[![](images/logo.gif)](index.html)
+## 2 What requirements do Xanadu systems aim to meet?
 
-[green](green/index.html)
-[gold](gold/index.html)
-[FAQ](FAQ.html)
-[discussion](discussion/index.html)
+### 2a
+
+Every Xanadu server is uniquely and securely identified.
+
+### 2b
+
+Every Xanadu server can be operated independently or in a network.
+
+### 2c
+
+Every user is uniquely and securely identified.
+
+### 2d
+
+Every user can search, retrieve, create and store documents.
+
+### 2e
+
+Every document can consist of any number of parts each of which
+may be of any data type.
+
+### 2f
+
+Every document can contain links of any type including virtual
+copies ("transclusions") to any other document in the system
+accessible to its owner.
+
+### 2g
+
+Links are visible and can be followed from all endpoints.
+
+### 2h
+
+Permission to link to a document is explicitly granted by the act of
+publication.
+
+### 2i
+
+Every document can contain a royalty mechanism at any desired
+degree of granularity to ensure payment on any portion accessed,
+including virtual copies ("transclusions") of all or part of the
+document.
+
+### 2j
+
+Every document is uniquely and securely identified.
+
+### 2k
+
+Every document can have secure access controls.
+
+### 2l
+
+Every document can be rapidly searched, stored and retrieved
+without user knowledge of where it is physically stored.
+
+### 2m
+
+Every document is automatically moved to physical storage
+appropriate to its frequency of access from any given location.
+
+### 2n
+
+Every document is automatically stored redundantly to maintain
+availability even in case of a disaster.
+
+### 2o
+
+Every Xanadu service provider can charge their users at any rate
+they choose for the storage, retrieval and publishing of
+documents.
+
+### 2p
+
+Every transaction is secure and auditable only by the parties to
+that transaction.
+
+### 2q
+
+The Xanadu client-server communication protocol is an openly
+published standard. Third-party software development and
+integration is encouraged.
+
+---
+
+## 3 What software meets some of the Xanadu requirements?
+
+### 3a
+
+[The World Wide Web](http://www.w3.org/) (also called WWW or
+simply the Web) was partially inspired by the Xanadu ideas and supports
+requirements 2a-2e, 2k-2l and 2q. The XHTML standards additionally
+support requirement 2f.
+
+### 3b
+
+[HyperWave](http://www.hyperwave.com/) (also known as
+Hyper-G) is based on the Xanadu ideas and supports requirements 2a-2e,
+2g-2h, 2j-2l and 2q.
+
+### 3c
+
+[Microcosm](http://www.multicosm.com/) has also been influenced
+by the Xanadu ideas and supports requirements 2d, 2g and 2j. "Webcosm"
+additionally supports requirement 2b.
+
+### 3d
+
+[Lotus Notes](http://www.notes.net/) (now owned by IBM, and
+integrated with the Web under the name Domino) was also influenced by
+the Xanadu ideas.
+
+---
+
+## 4 What is the history of the Xanadu system?
+
+Ted Nelson thought up the whole thing in 1960, and has been
+speaking and publishing about the idea since 1965. In that year
+he also coined the terms "hypertext" and "hypermedia" for
+non-sequential writings and branching presentations of all types.
+(The term "interactive multimedia" seems to have become popular
+recently.)
+
+Since that time there have been a long series of changing designs
+embodying these ideas:
+
+1960:Nelson's designs showed two screen windows connected by
+visible lines, pointing from parts of an object in one window to
+corresponding parts of an object in another window. No existing
+windowing software provides this facility even today.
+
+1965:Nelson's design concentrated on the single-user system and
+was based on "zipper lists", sequential lists of elements which
+could be linked sideways to other zipper lists for large
+non-sequential text structures.
+
+1970:Nelson invented certain data structures and algorithms
+called the "enfilade" which became the basis for much later work
+(proprietary to Xanadu Operating Company, Inc. until 24 August 1999)
+
+1972:Implementations ran in both Algol and Fortran.
+
+1974:William Barus extended the enfilade concept to handle
+interconnection.
+
+1979:Nelson assembled a new team (Roger Gregory, Mark Miller,
+Stuart Greene, Roland King and Eric Hill) to redesign the system.
+
+1981:K. Eric Drexler created a new data structure and algorithms
+for complex versioning and connection management.
+
+The Project Xanadu team completed the design of a universal
+networking server for Xanadu, described in various editions of Ted
+Nelson's book "Literary Machines" (see answers 6a and 6b
+below).
+
+1983:Xanadu Operating Company, Inc. (XOC, Inc.) was formed to
+complete development of the 1981 design.
+
+1988:XOC, Inc. was acquired by Autodesk, Inc. and amply funded,
+with offices in Palo Alto and later Mountainview California. Work
+continued with Mark Miller as chief designer.
+
+The 1981 design (now called Xanadu 88.1) was topped off but Miller
+began a redesign. Xanadu 88.1 was not subjected to quality
+control or released as a product.
+
+Dean Tribble and Ravi Pandya became co-designers and work on the
+redesign continued.
+
+1989:The World Wide Web, Hyper-G
+and Microcosm projects are initiated, all inspired or
+influenced by the Xanadu ideas.
+
+1992:Autodesk entered into the throes of an organisational
+shakeup and dropped the project, after expenditures on the order
+of five million US dollars. Rights to continued development of
+the XOC server were licensed to Memex, Inc. of Palo Alto,
+California and the trademark "Xanadu" was re-assigned to Nelson.
+
+1993:Nelson re-thought the whole thing and respecified Xanadu
+publishing as a system of business arrangements. Minimal
+specifications for a publishing system were created under the name
+"Xanadu Light", and Andrew Pam of
+[Serious Cybernetics](http://www.sericyb.com.au/) in
+Melbourne, Australia was licensed to continue development as
+[Xanadu Australia](http://www.xanadu.com.au/).
+
+1994:Nelson was invited to Japan and founded
+the Sapporo HyperLab. Memex changed their name to Filoli.
+[SenseMedia](http://www.sensemedia.net/) became the second
+Xanadu licensee under the name of "Xanadu America".
+
+1996:Nelson became a Professor of Environmental Information at
+the [Shonan Fujisawa Campus](http://www.sfc.keio.ac.jp/) of
+[Keio University](http://www.keio.ac.jp/). Initial draft of
+text transclusion proposal released.
+
+1997:Initial draft of [OSMIC](http://www.xanadu.com.au/OSMIC/)
+specifications released. Internet-Draft on
+[Fine-grained
+Transclusion in HTML](http://www.xanadu.com.au/archive/draft-pam-html-fine-trans-00.txt) released.
+[Transpublishing and
+transcopyright](http://www.xanadu.com.au/ted/TPUB/) start to be used on the Web.
+
+1998:Nelson received his first award for his work on Xanadu
+and hypermedia, the 1998 [Yuri Rubinsky
+Insight Foundation](http://www.yuri.org/) lifetime achievement award.
+
+1999:Open Source release of Xanadu 88.1 and 92.1 code under the
+names [Udanax Green](http://www.udanax.com/green/) and
+[Udanax Gold](http://www.udanax.com/gold/) respectively.
+
+2001:Nelson
+[awarded](http://www.xanadu.com.au/mail/xanews/msg00017.html)
+the medal and title of "Officier des Arts et Lettres" by the French
+Minister of Culture for his work on Xanadu and hypermedia.
+
+---
+
+## 5 How can I contact Project Xanadu?
+
+### 5a
+
+#### The Xanadu Team
+
+Email
+Write to [xanadu-request@xanadu.com.au](mailto:xanadu-request@xanadu.com.au)
+to join the Xanadu mailing list. Members of the Xanadu team monitor and
+contribute to the list on a regular basis.
+
+### 5b
+
+#### Project Xanadu
+
+Email
+[ted@xanadu.net (Ted Nelson)](mailto:ted@xanadu.net)
+Snail mail
+
+Project Xanadu, 3020 Bridgeway #295, Sausalito CA 94965 USA.
+
+### 5c
+
+#### Xanadu Australia
+
+Email
+[xanni@xanadu.com.au (Andrew Pam)](mailto:xanni@xanadu.com.au)
+Snail mail
+
+Xanadu Australia, P.O. Box 477, Blackburn VIC 3130 Australia.
+
+---
+
+## 6 What Xanadu-related merchandise is currently
+
+available?
+
+### 6a
+
+The following items are available from:
+
+    Mindful Press
+
+    3020 Bridgeway #295
+
+    Sausalito, California 94965 USA
+
+    Phone: +1 (415) 331-4422
+
+    Fax:   +1 (415) 332-0136
+
+    Email: ted@xanadu.net
+
+- Books:
+
+- "Computer Lib" by Ted Nelson, 1976 collector's edition for $100.
+
+- "Literary Machines" by Ted Nelson, 1993 edition for $25.
+  (Please enquire for pricing of Japanese edition).
+
+- "Xanadu Hypermedia Server documentation", 1993 draft for $250.
+
+- Papers:
+
+- "Virtual World Without End", 16 pages for $10.
+
+- "Xanadu Space 1993", 8 pages for $10.
+
+- Videos:
+
+- "A Technical Overview of the Xanadu System", NTSC $75, PAL $100.
+
+- Misc:
+
+- Xanadu Flaming X pin for $50.
+
+Add $5 postage and handling per $50 ordered, plus $15 for orders
+outside the USA. All prices quoted are in US dollars.
+
+### 6b
+
+"Literary Machines" is also available from:
+
+    Eastgate Systems
+
+    134 Main Street
+
+    Watertown MA 02172 USA
+
+    Phone: +1 (800) 562-1638 or +1 (617) 924-9044
+
+    Fax:   +1 (617) 924-9051
+
+    Email: info@eastgate.com
+
+    [
+    http://www.eastgate.com/catalog/LiteraryMachines.html](http://www.eastgate.com/catalog/LiteraryMachines.html)
+
+### 6c
+
+An audio cassette of "Xanadu - Publishing with Royalty", Ted's talk at
+ONE BBSCON in Atlanta August 1994, is available as tape #694-9 for US$7
+plus US$5 shipping and handling (international orders add 20%) from:
+
+    The ONE BBSCON Resource Link
+
+    3139 Campus Dr., Suite 300
+
+    Norcross, Georgia 30071-1402
+
+    Phone: +1 (800) 241-7785
+
+    Fax:   +1 (404) 447-0543
+
+---
+
+## 7 What is the history of the name "Xanadu"?
+
+### 7a
+
+Marco Polo mentioned the original palace "Shan-Du", somewhere
+in Mongolia, in his autobiography.
+
+### 7b
+
+Samuel Purchas wrote a book, "Purchas his Pilgrimage, or Relations of
+the World and the Religions observed in all Ages and Places discovered,
+from the Creation unto this Present... By Samuel Purchas. London, 1617"
+in which he related the following on page 472:
+
+In Xamdu did Cublai Can build a stately Palace, encompassing sixteene
+miles of plaine ground with a wall, wherein are fertile Meddowes, pleasant
+springs, delightfull Streames, and all sorts of beasts of chase and game,
+and in the middest thereof a sumptuous house of pleasure, which may be
+removed from place to place...
+
+### 7c
+
+[Samuel
+Taylor Coleridge](http://etext.lib.virginia.edu/stc/Coleridge/stc.html) published the poem ["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html), considered the sexiest in the English language, in 1816.
+Supposedly Coleridge fell into an opiate trance while reading the passage
+in "Purchas his Pilgrimage" mentioned in answer 7b
+above and wrote a thousand lines in his mind, but was interrupted
+while trying to write it down by the infamous "person from Porlock"
+who bothered him on trivial business and made him forget the rest of
+the poem. This has been disputed by scholars who didn't believe there
+actually could have been any more to the poem.
+
+### 7d
+
+John Livingston Lowes wrote a book called "The Road to Xanadu: A Study
+in the Ways of the Imagination" which was published by Houghton Mifflin
+(Boston) in 1927.
+
+Lowes' book traces an amazing hypertext -- the reading of [Samuel
+Taylor Coleridge](http://etext.lib.virginia.edu/stc/Coleridge/stc.html) -- by starting from Purchas' book and any others
+which Coleridge mentions in his journals, letters, etc., and moving
+on from there to any books mentioned in the text or footnotes of these
+books, and so onwards through yet other books that Coleridge may well
+have consulted -- because we know he consulted others which recommended
+or mentioned them...
+
+Along the way, Lowes discovered many instances of the workings of what
+Coleridge himself termed "the _hooks-and-eyes_ of the memory" -- hyperlinks
+again: for this is Coleridge's own term for them.
+
+It appears that Coleridge read very widely in the travel literature of his
+day, and did indeed tend to obtain many of the books referenced in books he
+was reading... and that as he went, his memory was saturated with the more
+striking phrases from these many books, and then _linked_ them
+associatively...
+
+And Lowes' book itself is a gigantic hypertext, linking sources
+in Coleridge's reading not only for "The Ancient Mariner" but also for
+[
+"Kubla Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html) -- and along the way touching on an extraordinary variety
+of topics. Lowes' book is, when all is said and done, one of the greatest
+detective and scholarly hypertexts of all time.
+
+### 7e
+
+Orson Welles, in his famous film "Citizen Kane", named the palace of
+Charles Foster Kane "Xanadu" after the Coleridge
+[poem](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html).
+It was based on the real life palace of San Simeon owned by William
+Randolph Hearst.
+
+### 7f
+
+Ted Nelson named his World Publishing Repository (trademark of Project
+Xanadu) project after the Coleridge
+[poem](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html),
+to suggest "the magic place of literary memory where nothing is
+forgotten".
+
+### 7g
+
+The secret hideout of Mandrake the Magician in the comic strip of the
+same name was called "Xanadu" (presumably after the Coleridge
+[poem](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html)).
+
+### 7h
+
+The rock group Rush released a song called Xanadu, obviously inspired by
+["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html), on their 1970s album "Farewell to Kings".
+
+### 7i
+
+The 1980 movie "Xanadu" starring Olivia Newton-John as a muse was also
+named after the Coleridge
+[poem](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html),
+as an allusion to literary inspiration. She also sang the title song.
+
+### 7j
+
+The pop group "Frankie Goes To Hollywood" released a 1984 album named
+"Welcome To The Pleasure Dome", on which the title song contains the
+line "In Xanadu did
+[Kubla
+Khan](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html) a pleasure dome erect".
+
+### 7k
+
+Greg Bear used
+["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html) in his 1984 science fiction novel "The Infinity Concerto" and
+its sequel "The Serpent Mage" (collectively published as "Songs of Earth
+and Power"), in which the poem is considered a song of power whose
+completion would have vast political and social implications. The book
+also features a massive palace called Xanadu.
+
+### 7l
+
+David Butler based the plot of his 1986 science-fiction novel "The
+Men Who Mastered Time" around the story of
+["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html).
+
+### 7m
+
+Douglas Adams used the story of the creation of the Coleridge
+[poem](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html)
+mentioned in answer 7c above as a central part of the
+plot of his science-fiction novel "Dirk Gently's Holistic Detective
+Agency".
+
+### 7n
+
+Douglas Adams wrote a 1990 BBC Television documentary called
+"Hyperland" starring himself, former "Doctor Who" Tom Baker, Ted
+Nelson and many computer industry luminaries. The documentary
+discussed the Xanadu system and quoted
+["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html).
+
+### 7o
+
+Jane Yolen edits a "Xanadu" series of fantasy anthologies by top fantasy
+authors published by Tor Fantasy since 1993. In the introduction to the
+first volume, she gives
+["Kubla
+Khan"](http://etext.lib.virginia.edu/stc/Coleridge/poems/Kubla_Khan.html) as the inspiration for the title and suggests that "the word
+Xanadu has come to be a generic name for any magical realm."
+
+### 7p
+
+Pride Music released a cover of the title song from the 1980
+movie "Xanadu" for the annual Sydney Gay and Lesbian Mardi Gras
+in 1995. The CD single is called "Xanadu" by Olivia Featuring Paula and
+contains five remixes of the song plus a song called "Unconditional Love".
+Pride Music kindly granted us permission to provide one track from the
+CD on the [Xanadu Australia home page](http://www.xanadu.com.au/) as our theme song.
+
+---
+
+## Credits
+
+This FAQ was written by [xanni@xanadu.com.au
+(Andrew Pam)](mailto:xanni@xanadu.com.au). Much of the material in the answers
+to questions 1, 4 and 6 was graciously provided by [ted@xanadu.net (Ted Nelson)](mailto:ted@xanadu.net). Thanks to
+[hipbone@earthlink.net (Charles
+Cameron)](mailto:hipbone@earthlink.net) for answers 7b and 7d.
 
 [download](green/download/index.html)
 [download](gold/download/index.html)

--- a/md/future.md
+++ b/md/future.md
@@ -1,0 +1,314 @@
+# ![](/images/logo.gif)Xanadu
+
+The Information Future
+
+- One simple idea
+
+- The multimedia connection problem
+
+  - If you are an AUTHOR or ARTIST
+
+  - If you would like to READ, ROAM, EXPLORE and
+    EXPERIENCE
+
+  - If you are a PUBLISHER
+
+- The publication contract
+
+  - If you or your company would like to be a SERVICE
+    PROVIDER
+
+- How it works in detail
+
+- Freedom
+
+- Definition of terms
+
+  - Hypertext
+
+  - Hypermedia
+
+  - The repository network
+
+  - Automatic royalty
+
+  - Transpublication
+
+  - The copyright solution
+
+  - Open hypermedia publishing
+
+- Explaining it quickly
+
+## One simple idea
+
+There are many views of just what tomorrow's electronic media will be,
+and how they will reach the consumer. The Xanadu plan proposes a single
+unified world of data to which everyone will have point-and-click access
+from whatever computer, videogame or multimedia player they want to use.
+
+Think of it as a real data bank. Just as you put your money in a bank
+for safekeeping, you can put your data on the Xanadu network for
+safekeeping. And in the same way that your money can earn interest in a
+bank, your data can make money too. If anybody wants pieces of it, they
+buy it from the network and you get paid. You get paid even if other
+people use parts of it in their work. On the Xanadu network, any object
+may quote from any other, since the material quoted is bought from the
+original publisher at the time of delivery. We've succeeded in cleaning
+up the copyright problem for computer networks.
+
+Besides what individuals and publishers put in, new forms of
+interconnection and quotation are possible creating a new world of
+metamedia objects.
+
+## The multimedia connection problem
+
+Current "multi-media standards" as practiced by the industry are built
+on a closed-unit philosophy, whereby multimedia objects are
+encapsulations that do not allow interconnection between documents.
+This is a dead-end world.
+
+Xanadu structure is built for OPEN HYPERMEDIA
+PUBLISHING, allowing free interconnection among documents. Every
+author of a new document is free to connect to previous documents,
+including quotation, without pre-arrangement or advance payment.
+
+### If you are an AUTHOR or ARTIST:
+
+You can make your work available with very little difficulty -- whether
+it's poetry or a novel; photography, music or movies; or some new medium
+you have invented. As long as it's digital, you can publish it yourself
+on Xanadu at a small cost (depending on the medium and how much computer
+storage space it takes). Or you can give the job of publishing and
+marketing your work to someone else.
+
+Once your materials are on the network, anyone with a modem can buy a
+copy and make connections to it that make it even more interesting or
+useful for others. Each time material from your document or object is
+bought by anybody, you can get a royalty on that fragment.
+
+### If you would like to READ, ROAM, EXPLORE and
+
+EXPERIENCE:
+
+All you will need will be your computer, a modem or other network
+connection and a Xanadu exploration program, then you simply sign up for
+an account with your preferred Xanadu service
+provider. Different service providers will offer different
+conveniences. One may be near your home. Another may offer better
+prices or a special deal you like. Many will be on the Internet. But
+as soon as you connect to one service provider, YOU HAVE ACCESS TO
+WHAT'S ON ALL OF THEM.
+
+Now, starting anywhere, you can point and click, sending for text,
+graphics, music and audio, photographs, movies and everything else in
+the ever-expannding world of Xanadu literature. You pay for whatever
+you retrieve, but you need only buy those parts you find interesting or
+useful. To help you do this,information will be available to you about
+the author, type and price of a document. Also available will be reviews
+by others, electronic "dust jackets", advertising summaries with
+quotations prepared by the publishers themselves. There is no
+distinction between just looking at a document and saving it since
+anyone with a modem can save whatever is sent. Therefore, the user is
+free to keep a copy of what has been looked at, but the price for this
+is low.
+
+A user may simultaneously read and publish like users on electronic
+forums. But in our system there are no boundaries to forums or
+discussion groups, royalty is built in and links among documents are
+part of the docuverse.
+
+### If you are a PUBLISHER:
+
+The publisher is the person or company that takes responsibility for the
+contents of the published material. In the paper world, the publisher
+often arranges for the production of a work, its manufacture (as a book
+or other physical object) and for the marketing and distribution. In
+return the publisher collects a percentage of the profits. It is much
+the same in the Xanadu world. The publisher is the person or company
+that signs the deal with a Xanadu service provider. The publisher will
+still need to perform all of the usual functions including marketing,
+but Xanadu will now perform in essence the manufacture and distribution
+functions.
+
+## The publication contract
+
+Just as a paper publisher contracts with a printer, a Xanadu publisher
+contracts with a Xanadu service provider. A formal contract is signed
+arranging payment for storage and other aspects. If you are the
+publisher, you are responsible for avoiding publishing material you do
+not own or that violates the law or rights of others who may sue you.
+As a publisher you agree to abide by the laws. You agree to pay in
+advance for at least three years' storage of your material in three
+places for safety. Publishers pay for storage, users pay for delivery.
+You also agree to permit others to make links or transclusions
+(quotation pointers) to your document.
+
+As the publisher, you decide the amount of royalty and you receive
+whatever royalties are paid by users of your document on the network.
+You must then distribute these royalties to participating authors or
+others with whom you have made payment commitments.
+
+### If you or your company would like to be a SERVICE
+
+PROVIDER:
+
+The Xanadu network will have many service providers of all kinds and
+sizes, ranging from individuals publishing the work of a small town or
+neighborhood to huge telephone companies. There will be many ways to
+participate and many ways to compete or find a particular niche in the
+market. All supply the same basic service. All Xanadu service
+providers will use a common system of software and supply material on
+request by users, forming one great common pool.
+
+## How it works in detail
+
+Think of the Xanadu network as a single place for storing and publishing
+electronic documents and selling digital objects with interconnections
+and new objects made from them. The Xanadu network is not necessarily
+physically connected, but an affiliation of centres whose server
+computers behave as a single entity using the Xanadu publication method.
+These are run by companies and individuals who choose to be service
+providers using the shared method.
+
+ALL MATERIAL IS ONE
+All the contents on all of the Xanadu storage servers act as a
+single pool. You can send for any part of any document or link to or
+quote any part of any document.
+
+THE REQUESTS FAN OUT
+Users ask for pieces of documents and objects. A request is
+received by the user's session node which fans it out to wherever the
+material is.
+
+AND THE PAYMENTS COME BACK
+The user's payment is correspondingly sent to those publishers
+involved with the transaction.
+
+## Freedom
+
+People are free to read anything. Xanadu creates a point-and-click
+universe with user freedom.
+
+All hypertext jumps are reversible. Under other systems the reader is
+often tunnelled into reading in only one direction on any given
+document. We believe the reader must always be free to go back, turn
+the page, fast-forward or access the original document of a quote.
+
+The system will not keep records of who sends for what; otherwise
+reading becomes a political act.
+
+People will be free to jump into a document at any place and use it
+according to their own preferences.
+
+## Definition of terms
+
+HYPERTEXT
+The computer screen makes new forms of writing possible that are not
+sequential. "Hypertext," a term coined by us, mean non-sequential
+writing for the computer screen (our term "hypertext" is now in wide
+popular usage).
+
+HYPERMEDIA
+"Hypermedia," another of our terms, extends the hypertext concept to
+sound, video and computer graphics. Multimedia presentations where the
+user may branch and explore have now become recognised as an exciting
+new educational and artistic medium. The Manhole, Virtual Valerie and
+Carmen Sandiego are among titles already popular in this area. CD-I and
+3DO are among the hardware players being fielded. Some use the term
+"interactive multimedia," but it is indeed the same thing as hypermedia.
+
+THE REPOSITORY NETWORK
+We think the future goes far beyond hardware players and plastic
+disks. Tomorrow's publishing for computer screens will be principally
+over networks. Xanadu has been planned from the beginning as a network
+for delivery of copyrighted media to users on demand.
+
+AUTOMATIC ROYALTY
+Our copyright solution has always been for the user to pay a small
+royalty to the media publisher for every byte sent. Instead of buying
+whole documents, this allows the user continually to pick and choose on
+line. This is necessary in a hypermedia world, since the user will
+typically not buy whole publications, but move and ramble unpredictably.
+The royalty is paid automatically at the instant of delivery, only and
+exactly for the portion sent.
+
+TRANSPUBLICATION
+This in turn means that any publisher in our system may quote any
+other publisher freely since the "quotation" is a pointer to the
+original publication. The user automatically sends for the quotation
+from the original publisher, paying the royalty to the original
+publisher.
+
+Material which is virtually included in this way, from one document to
+another, we call transcluded, and this form of quoting in a new
+published document we call transpublication.
+
+Anyone is free to transpublish anything since it still belongs to the
+original publisher and stays in the original publisher's storage space.
+And the original publisher gets the royalty on the portions which are
+transpublished.
+
+THE COPYRIGHT SOLUTION
+For all participants within the Xanadu network, this cleans up the
+copyright issue:
+
+- Nothing is misquoted.
+
+- Nothing is quoted out of context (since original context is
+  immmediately available: the customer has the address of the portion in
+  its original setting).
+
+- Royalty is automatic to the original publisher.
+
+- Credit is automatic to the original author or authors.
+
+Everything may be freely re-used and quoted anywhere in our network in
+this manner. Its publication on our network includes permission for
+this arrangement.
+
+We believe this will be the universal solution to the copyright issue in
+our time and that others operating in this computer multimedia area do
+not yet understand this.
+
+OPEN HYPERMEDIA PUBLISHING
+We call the whole system of publication "open hypermedia publishing"
+because anyone can link to, and re-use, materials of any kind throughout
+the network. We believe that Xanadu Open Hypermedia Publishing is the
+publishing medium of the future, combining all forms of media -- text,
+graphics, audio and music, video, simulations, data structures -- into
+tomorrow's new information world.
+
+## Explaining it quickly
+
+- Xanadu is a system for the network sale of documents with automatic
+  royalty on every byte.
+
+- The transclusion feature allows quotation of fragments of any size
+  with royalty to the original publisher.
+
+- This is an implementation of a connected literature.
+
+- It is a system for a point-and-click universe.
+
+- This is a completely interactive docuverse.
+
+---
+
+"Xanadu: The Information Future" was compiled from the writings of Ted
+Nelson by Katherine Phelps of Xanadu Australia, PO Box 4234,
+Croydon Hills VIC 3136, Australia. Email:
+[xanni@xanadu.com.au](mailto:xanni@xanadu.com.au).
+"Xanadu" is a trade and service mark of Xanadu On-Line
+Publishing, 3020 Bridgeway #295, Sausalito CA 94965 USA. Copyright (c)
+1994 Xanadu Australia and Xanadu On-Line Publishing.
+
+[download](green/download/index.html)
+[download](gold/download/index.html)
+[history](history/index.html)
+[Related Sites](related.html)
+
+_[contact us](contact.html)_
+or [![](images/cmn.gif)](http://www.blindpay.com/crit-me-now.cgi)
+
+[![Golden Key](images/key.gif)](http://www.privacy.org/ipc/) [![Blue Ribbon](images/ribbon.gif)](http://mirrors.yahoo.com/eff/blueribbon.html)

--- a/md/ideal.md
+++ b/md/ideal.md
@@ -1,0 +1,252 @@
+---
+
+
+Theodor Holm Nelson
+
+# ![](/images/xlogo.gif)The Xanadu Ideal
+Copyright (c) 1993 Xanadu On-Line Publishing
+
+
+---
+
+**THE XANADU SYSTEM IS COMPLETELY DIFFERENT FROM EVERY OTHER PLAN FOR
+MULTIMEDIA AND ELECTRONIC LITERATURE.**
+
+DO NOT CONFUSE XANADU WITH ANYTHING ELSE.
+
+## Why do they call us a cult?
+
+Because we think differently from everyone else. We are striving to
+create a unified, universal literature, _available to everyone both as
+readers and contributors_, instantly available everywhere, with the
+ability to publish connections freely. That is, anyone may publish
+footnotes, comments, disagreements; and anyone may quote, republish,
+anthologise and otherwise re-use everything in the system -- provided
+that the republication stays within the Xanadu world. All this includes
+automatic and innocuous royalty.
+
+This raises many questions which cannot all be answered briefly.
+Suffice it to say that we have many answers. A few follow.
+
+## What is Xanadu Publishing?
+
+The term "universal electronic library" has been suggested. Perhaps
+"universal bookstore" is more like it. World Publishing Repository(TM)
+is perhaps the most appropriate term.
+
+The Xanadu system has been designed from the literary point of view, the
+computer point of view, the business point of view and the legal point
+of view.
+
+The Xanadu publishing system will be a licensed method of on-line
+electronic publication provided by vendors throughout the world.
+"Publication" consists of placing a digital document somewhere in the
+repository network. A document may include text, picutres, audio,
+movies and nay other form of digital information. Readers, or users,
+are of course at screens. Any user in the world may send for any
+document, or any part of a document. The publisher pays only for the
+storage; the user pays for delivery, including a royalty to the
+publisher.
+
+The user obtains a digital copy of everything he or she sends for -- to
+keep or discard. The user may point and click to travel among
+documents, obtaining only the small part needed to keep going.
+
+Staying within the Xanadu on-line world, anyone may publish a connection
+to a document -- a comment, illustration, disagreement, or link of any
+other type; and anyone may quote from a published Xanadu document, since
+the quotation is bought from the original publisher at the time of
+delivery. The publisher agrees to be legally responsible for the
+contents and agrees to interconnection by anyone.
+
+## Based on literature as we know it
+
+"Literature" is a debugged system used and understood throughout the
+world. _Documents_ are information packages with points of view,
+_literature_ is a system of interconnected documents. Xanadu is
+intended to allow millions of points of veiw and to keep track exactly
+of all their interconnections.
+
+## No point of view
+
+Other electronic media have viewpoints deeply embedded in the design of
+the system (such as keywords and categories). Xanadu places all the
+viewpoints where they belong, in the separately owned documents and
+keeps the overall system viewpoint-free.
+
+## Simplicity & Ease, point-&-click
+
+The system is intended for a point-and-click universe that even a child
+can find her or his way around in. The user points at the desired link
+on the screen; the user's screen machine -- that is, underlying computer
+-- automatically purchases the linked material from its publisher and
+brings that material to the screen. Thus anyone can go from document to
+document within this universe without having to learn "computer
+commands."
+
+## The Next Fragment
+
+The user does not have to buy whole documents. Instead, she or he
+simply purchases the next fragment desired. These may add up to whole
+documents, or not.
+
+## Simple basic concepts
+
+The basic concepts are simple but sophisticated and powerful, and can be
+built into structures and uses of every kind.
+
+The concepts are the _document_, the _link_ and the
+_transclusion_.
+
+- A _document_ is an information package with a point of view.
+
+- A _link_ is a connection between parts of documents, or parts of
+  one document. A link is owned by its publisher, but may be connected to
+  documents owned and published by others. Links may be of many types.
+
+- A _transclusion_ is a part of a document (call it A) that
+  happens to be stored as part of another document (call it B), and is
+  brought from that other place in B whenever A is sent for.
+
+## Inside-out from today's electronic media
+
+Xanadu is different from, or opposite to, almost everything that
+is happening in the field of electronic media, including:
+
+- Not like CD-ROM
+
+CD-ROM is not electronic publishing. It is publishing plastic. It has
+boundaries. No one may interconnect to a document published in CD-ROM.
+
+- Not like CLOSED MEDIA UNITS (such as ACROBAT(TM))
+
+Many standards exist for closed media which no one may connect data
+to. These include: CD-ROM (already mentioned). The new Adobe Acrobat,
+for instance, mimics paper and is a closed application. So are
+PostScript(TM), SGML, HyperCard(TM), and scripting languages offered by
+Kaleida, General Magic, etc., etc.
+
+- Not like TEXT SEARCH
+
+Searching text for particular words is a useful tool. However, it
+only works when the authors of the document use the same terms you
+expect. For the World Publishing Repository, we rely much more on links
+that allow instantaneous travel between documents.
+
+- Not like ON-LINE CONFERENCES, DISCUSSION GROUPS, FORUMS, NEWSGROUPS
+  (Boundaries, Topics)
+
+On-line conferences (called various things) are very popular these
+days, but the problem is that the conversation among the many
+participants sprawls in all directions.
+
+The usual solution is to have a closed boundary around the original
+"topic" of the discussion, sternly administered by an editor or manager
+(or, in the case of Prodigy(TM), by a comprehensive system of automatic
+censorship).
+
+We find this unacceptable.
+
+In Xanadu conferences, because of the unique connection system, the same
+materials may be simultaneously in many different discussions managed by
+different people and with different boundaries reflecting different
+points of view.
+
+## Open use -- all connect & re-use
+
+Anyone may publish links to any document already on Xanadu. Likewise
+anyone may re-use material already on Xanadu as boilerplate, as long as
+that material is re-used by transclusion rather than by copying. This
+assures that every new use will be bought from the original publisher.
+
+## Universal
+
+This is a medium for publishing in all areas. Indeed, since we do not
+see boundaries between different areas, we see all publishing methods
+that restrict themselves to given areas as hobbled.
+
+## Populist
+
+Because it will be equally available to everyone at low cost, and open
+to all points of view, we believe Xanadu is a populist medium.
+
+## Generalist
+
+There are no sharp lines between subjects, and Generalists are those
+people who pursue their interests without regard to artificial boundary
+lines. There are more and more brilliant generalists throughout the
+world, but the existing publication media subdivide the world of ideas
+and information artificially. Xanadu does not.
+
+## Pluralist
+
+Many different points of view, including unpopular and eccentric ones,
+may be freely published in Xanadu, linked to the materials they agree
+and disagree with.
+
+In today's publishing world, only those viewpoints held by those with mondy, or other access to media, may be published. This is not the democratic ideal.
+
+## No boundaries
+
+There are no boundaries in Xanadu. A document may be of any size,
+spread across many disks in many places. Anyone may publish connections
+to the document.
+
+There are no boundaries to categories in Xanadu; you are not restricted
+to the way that someone else sees the world.
+
+## Controversy
+
+Open controversy and argument are not well represented by existing
+systems. We intend to change that.
+
+## Minority points of view
+
+Many points of view cannot be publicly expressed in today's world. We
+intend to change that.
+
+## Self-guided education
+
+Today's systems of education are deeply hampered by artificial
+categories and divisions among subjects, and by forms of teaching that
+make them uninteresting. Since Xanadu will allow anyone to explore any
+subject in his or her own style, we see it as a medium for true
+education.
+
+## "Just connect and keep going"
+
+The reader need not master computerish styles of interaciton; she or he
+need only start and one document and click across the universe from
+there.
+
+## Thought-out legally
+
+Many digital publishing systems have been built without understanding of
+the legal system and are building a field of naive expectations. Xanadu
+has been built with firm understanding of copyright and liability law.
+
+## Copyright innocuous
+
+Many computer people naively think that copyright will go away. We
+assume that it will not, and that the Xanadu system must work in a world
+of copyright law; but we are able to make copyright and royalty
+innocuous and smooth.
+
+---
+
+"Xanadu", "World Publishing Repository" and the flaming
+X logo are trade and service marks of
+
+Xanadu On-Line Publishing
+
+3020 Bridgeway #295, Sausalito CA 94965 USA
+
+[download](green/download/index.html)
+[download](gold/download/index.html)
+[history](history/index.html)
+[Related Sites](related.html)
+
+_[contact us](contact.html)_
+or [![](images/cmn.gif)](http://www.blindpay.com/crit-me-now.cgi)
+
+[![Golden Key](images/key.gif)](http://www.privacy.org/ipc/) [![Blue Ribbon](images/ribbon.gif)](http://mirrors.yahoo.com/eff/blueribbon.html)

--- a/md/inforights.md
+++ b/md/inforights.md
@@ -1,0 +1,83 @@
+Everyone is arguing about copyright and electronic publishing; few pay
+attention either to the law or the great possibility.
+
+By law, the publisher is the person or entity responsible for published
+content. And "Electronic Publishing" cannot, must not mean only closed
+objects that have to be used separately. The great possibility is a
+world of combinable objects that may be linked by users: **OPEN
+HYPERMEDIA PUBLISHING**.
+
+We want an enchanted grove, a fair playing field, where all connections
+and quotations are allowed and sorted out. Copyright law by itself
+won't do it; and so we extend the law by a system of contracts. If this
+is a world in which you would like to work and play, Welcome to Xanadu.
+
+---
+
+# BILL OF INFORMATION RIGHTS
+
+## in the Xanadu Publishing Universe
+
+Copyright (c) 1993 Xanadu On-Line Publishing
+
+---
+
+### AS A READER OR HYPERNAUT
+
+- by connecting to one Xanadu supplier, you connect to the whole
+  Xanadu universe.
+
+- you may point and click indefinitely from document to document or
+  within documents.
+
+- you may send for any part of any published object in complete
+  privacy; no record is kept.
+
+- you may keep what you send for (and get a receipt token to help file
+  it).
+
+- you may print it out and keep or give away the copy.
+
+### AS A PUBLISHER
+
+- you may link to, comment on, append to any published document.
+
+- you may quote any other document within the system by transclusion
+  pointer (the quotation is bought automatically from the original
+  publisher).
+
+- accordingly, you relinquish control of connections from other
+  documents.
+
+- your document is kept inviolate.
+
+- you may publish anything within the law.
+
+- you take responsiblity for the contents and all possible violations
+  of law and tort-- just as you do in paper publishing.
+
+### AS A SUPPLIER
+
+- you may locate anywhere, connect to your customers in any way.
+
+- charge what you like for storage and connection.
+
+- give credit, or accept payment or trade in any form.
+
+---
+
+"Xanadu" is a trade and service mark of
+
+Xanadu On-Line Publishing
+
+3020 Bridgeway #295, Sausalito CA 94965 USA
+
+[download](green/download/index.html)
+[download](gold/download/index.html)
+[history](history/index.html)
+[Related Sites](related.html)
+
+_[contact us](contact.html)_
+or [![](images/cmn.gif)](http://www.blindpay.com/crit-me-now.cgi)
+
+[![Golden Key](images/key.gif)](http://www.privacy.org/ipc/) [![Blue Ribbon](images/ribbon.gif)](http://mirrors.yahoo.com/eff/blueribbon.html)

--- a/md/transcopy.md
+++ b/md/transcopy.md
@@ -1,0 +1,346 @@
+transcopy
+
+( E36fix981014
+
+.html
+
+ 
+[To Xanadu Australia Home Page](../index.html)
+
+ 
+
+The following is the original paper on transcopyright.  A version
+was printed in the _Educom Review_, 32:1 (January/February 1997),
+32-5, under the title "Transcopyright: Dealing with the Dilemma of Digital
+Copyright."
+
+---
+
+Date of this cleanup: 98.10.14.
+
+Only change: bib.item.
+
+Some of original emphases still lost.
+
+transcopy E36
+
+.html
+
+asof 95.4.9
+**Transcopyright:**
+
+**Pre-Permission for Virtual Republishing**
+
+**Theodor Holm Nelson**
+
+**Project Xanadu, Keio University and University of Southampton**
+
+**e-mail ted@xanadu.net**
+
+ 
+
+ 
+
+**SUMMARY**
+
+The on-line copyright problem may be resolvable by a simple, sweeping
+permission method.  This proposed system, which anyone may use, allows
+broad re-use of materials in exchange for automatic tracking of ownership. 
+Payment goes to the original publisher and credit to the original author. 
+Nothing is misquoted, nothing is out of context (since the original context
+is immediately available), and users are not spied upon.
+
+A wording and an abbreviation for this permission system are proposed
+here.
+
+**INTRODUCTION**
+
+Someone who asks, "How do we keep people from stealing food?" is asking
+you to consider only his side of the issue, without addressing underlying
+problems.  But it might be sensible to ask another question in reply. 
+If we ask, "How can the people obtain food?", perhaps both problems can
+be solved together.
+
+That is how I see the issue of copyright in digital media.  Those
+who merely ask, "How do we prevent copyright infringement?" are only asking
+the first question without addressing the second.  There is a hunger
+for the re-use of media.  If we can find a legitimate way to feed
+this hunger, then perhaps the stealing will not be necessary.
+
+Today's central controversy seems to be the question of how to manage
+copyright and royalty on the sale of digital content.
+
+The standard question has been, "How do we prevent infringement?" 
+If we re-frame the question as "How can we allow re-use?", the solution
+may be simpler and more powerful than everyone thinks, with benefits for
+everyone.
+
+This reformulates an idea which occurred to the author in the fall of
+1960, and which since then has been an implicit part of the Xanadu Project
+(1), an ambitious system of hypermedia publishing servers with deep version
+management.  Because the project has been controversial and beset
+with difficulties, our fundamental copyright proposal was not understood. 
+And because this method was embedded in the software that had been
+
+designed for the Xanadu project, it was not recognized or expounded
+as a separate legal permission doctrine.
+
+In this paper, we now separate that copyright method from its software
+history, and present it as a method anyone can use.  It is a legal
+permission doctrine with far-reaching consequences, whose benefits may
+be considerable.
+
+**THE OBJECTIVE**
+
+From the beginning, the objective of Project Xanadu was to facilitate
+a new kind of literature: a new populist medium, a many-to-many publishing
+system, not centralized in editorial and publishing companies, but open
+to anyone.  It was intended to create a new kind of freedom of the
+press, and make possible a deeper understanding of published materials
+(2).
+
+But this would not mean simply electronic availability of closed documents;
+we would also need to re-use existing materials, and the computer could
+help keep this re-use orderly (and do so without spying on users).
+
+The idea was to preserve integrity, copyright and royalty for digital
+materials, yet allow everyone freely to re-use these materials, which would
+retain their identity at all times.  By allowing everyone to republish
+all materials, this would effectively define a new system of fluid, digital
+transmedia, with universal freedom of re-use and visualization.  All
+different republications could in principle be viewed side-by-side by the
+user, thus leading to
+
+greater understanding of the material and of the points of view of
+the different documents, their authors and republishers.
+
+The scheme is simple: under this arrangement, everyone is free to republish
+digital materials virtually, as quotations, anthologies and collages, provided
+that the republication is virtual: that is, provided that the republisher
+only provides instructions for acquisiton and assembly of the parts, and
+each copy of previously-published bytes is separately purchased from the
+original publisher(s) at the time of delivery.  A republisher only
+distributes pointers showing how to obtain the material, and in what new
+context(s) to place the material; each recipient buys these materials independently.
+
+This method provides each receiving party with a properly-owned, independent
+copy of the materials, all purchased anew from the original publisher. 
+What may be just as important, it provides incentives for participation
+and a method for honest re-use in a system from which all benefit.
+
+**A PERMISSION DOCTRINE**
+
+What is proposed here turns out actually to be, at its center, a permission
+doctrine.  A new permission doctrine may be easily added to our culture;
+a variety of permission doctrines are already popular, such as "shareware"
+and "all rights reserved, except that churches may reprint freely."
+
+In this proposed permission doctrine, the copyright holder gives permission
+for republication, PROVIDED THAT the material is sent to users only as
+an address for the material being republished, indicating what material
+is to be included in what new context, and inviting the recipient to purchase
+the content bytes anew from their present publisher.  When a recipient
+purchases material, the material is sent with identifiers as to its origin;
+and the user has software enabling these identifiers to be kept. 
+This has a number of benefits: (1) the user knows the origin; (2) this
+identification can be part of a proof of purchase; (3) in principle, any
+recipient may republish in the same fashion, ad infinitum.
+
+LONG FORM PERMISSION
+
+To allow this, the copyright holder must therefore make a statement
+like the following.  (Note that I am still tinkering with the provisions
+and wording.)
+
+"Permission is granted to all parties in the universe to re-publish
+the bytes of these materials virtually in new on-line contexts, provided
+(1) that such virtual republication consists of transmitting only a purchase
+address for bytes to be included in a particular new context; and provided
+(2) that the present publisher is notified of any such virtual republication."
+
+This may be adequate to achieve the desired result, as we will consider
+below.  It also leaves room for a number of possible variations.
+
+**IRONICALLY SIMPLE**
+
+This may seem over-simple, when mighty technical and legislative solutions
+are being sought by so many parties.  But it shifts the ground of
+the issue.
+
+The new ground becomes the issue of CONTEXT RELINQUISHMENT-- the publisher's
+willingness to allow the material to be used in unpredictable contexts,
+in return for royalty, credit, and the immediate availability of the original
+contexts for further purchase, inspection and comparison.
+
+This is a tradeoff.  We expect publishers-- especially small, non-traditional
+publishers and self-publishing individuals-- to be invigorated by the notion
+of their materials being available for universal sale and re-use, to their
+benefit.  More traditional publishers and authors may hesitate, not
+recognizing that all the traditional objectives may be satisfied by this
+system.
+
+**IMPLIED ASPECTS**
+
+Implied in this method are certain other aspects of implementation. 
+For instance, the user must be given a receipt for each portion purchased,
+so that the received materials may be proved a legitimate copy.  A
+survivable memorandum of origin (the address from which purchased) must
+also accompany the repurchased materials, making virtual republication
+possible once again (by the new recipient).  And the republisher must
+notify the original publisher of the republication, so that these re-uses
+may be seen.
+
+**SUPPORTING SOFTWARE ASPECTS**
+
+This permission doctrine has certain minimal requirements for supporting
+software.  Certain unusual software features are required:
+
+Server-side software: The server program should have the ability to
+sell materials in small amounts, ideally at a fixed price per byte, delivering
+the materials with a receipt and identity notification.
+
+Client-side software:  Certain detailed features of an unusual
+nature are required in the user's programs.
+
+1.  Viewer program with purchase methods.  Any recipient must
+have a viewer program ("client software") which has methods for purchasing
+the required bytes, and which retains the identity of bytes purchased.
+
+2.  Editing program which retains identities of portions. 
+Any republisher must have an editing program which retains the original
+identity and addresses of the edited materials, even as they become cut
+down (or re-expanded by additional purchases from the original).
+
+3.  Stripping program.  After an author has finished creating
+a document which is to include republished material, a special stripping
+program (or feature) must then prepare the document for skeleton transmission,
+stripping out the actual bytes and substituting the original addresses
+in the necessary format for their repurchase.
+
+**OWNERSHIP OF EACH FINAL COPY**
+
+The recipient who purchases the suggested materials owns a final copy,
+like any book, each portion legally purchased.  Even if the materials
+are later withdrawn from sale, each copy already acquired in this way retains
+itsownership status as the possession of the recipient.
+
+**COMPATIBILITY, INTEROPERABILITY**
+
+Note that any party may offer transcopyright; and note that different
+variations of this arrangement, with different details of availability,
+may be mixed and matched in a given document (see below).  Regardless
+of such variations, a legitimate mixed copy is still owned by the final
+recipient.
+
+**THE PROPOSED FORMAT AND ITS LEGAL STATUS**
+
+I propound for this permission system an extremely simple presentational
+format. A publisher signifies participation by the following notice, in
+the place of the usual copyright notice:
+Trans(c)(year)(name)
+
+For example,
+Trans(c)1995 Irving Snerd
+
+This is a shorthand form of the long-form permission stated earlier,
+so that the publisher is spared having to include it.
+
+Some distribution agency or availability scheme should also be specified
+by the transcopyright grantor, as, for example:
+Trans(c)1995 Irving Snerd; administered Dun & Bradstreet.
+
+or
+Ziff-Davis Trans(c)1995 Irving Snerd.
+
+Either of these notifications tells all parties, in condensed form,
+(1) that copyright is claimed; (2) that transcopyright permission is granted,
+and (3)
+
+where the materials may be bought.
+
+It will be noted that the traditional copyright notice
+(c)1995 Irving Snerd
+
+is FULLY CONTAINED within the transcopyright notice, and so is still
+present.
+
+ 
+
+However, note also that this traditional copyright notice no longer
+has its former force in law, since by today's law an author now establishes
+copyright automatically by creating a work; so the copyright notice is
+now regarded as being a courtesy and a convenience.  Thus we are offering
+the transcopyright permission as a further courtesy, so that all parties
+will know how they may republish.
+
+By what authority is this a shorthand of the longer version?  I
+hereby DECLARE it to be such a shorthand form, just as the terms "shareware"
+and "copyleft," declared by Bob Wallace and Richard Stallman respectively,
+have come to represent their respective permission doctrines, both now
+widely accepted and used.  If others use the transcopyright notification
+with the intent given here, it will be recognized in law (like shareware
+and copyleft) as being synonymous with the longer permission notice.
+
+**VARIATIONS NOT COVERED;**
+
+**DIFFERENT JURISDICTIONS**
+
+This arrangement is for on-line screen viewing and keepage of digital
+data, not for paper or other solid media.
+
+A number of issues are not handled by this arrangement.  These
+include byte modification (such as morphing, bytewise graphical operations,
+and merged re-use of audio samples into a fused, mixed, inseparable recording). 
+It does not involve printout.  It does not cover site licensing for
+multiple users.  It does not include model releases, talent releases,
+or other forms of permission not strictly part of copyright.  It does
+not state how long materials will be offered for sale.
+
+Who settles these details?  This is within the scope of variation
+of the idea: different forms of transcopyright may be offered by different
+parties-- individuals, companies, or other administrations.  Any party
+offering transcopyright may bundle different kinds of permission into their
+own systems.  (For instance, the contracts of Project Xanadu will
+have specific clauses with respect to length of availability, paper printout
+and site licensing.)
+
+**ENFORCEMENT AND BENEFITS**
+
+This system is not automatically enforced, but neither is any other
+feasible electronic copyright system.  It is no more or less enforceable
+than any other.  The fact that it defines a convenient method for
+honest behavior, satisfying principal objectives of both publisher and
+republisher-- no longer "infringer," but  honest participant-- is
+a strong argument in its favor.
+
+ 
+
+ 
+
+---
+
+**ACKNOWLEDGMENT**
+
+My especial thanks to Robert W. Fiddler, Esq., of Great Neck, N.Y. for
+over twenty-five years of friendship, generous legal tutoring and delightful
+banter that have helped shape these ideas; but any errors, misunderstandings
+or improprieties are my own.
+
+**BIBLIOGRAPHY**
+
+1.   Nelson, Theodor Holm, _Literary Machines_. 
+Availabile from Mindful Press, 3020 Bridgeway #295, Sausalito CA 94965,
+USA.
+
+2.     Nelson, Theodor Holm, "Literature Unified
+by Transclusion."  _Communications of the ACM_, 1995.
+
+[download](green/download/index.html)
+[download](gold/download/index.html)
+[history](history/index.html)
+[Related Sites](related.html)
+
+_[contact us](contact.html)_
+or [![](images/cmn.gif)](http://www.blindpay.com/crit-me-now.cgi)
+
+[![Golden Key](images/key.gif)](http://www.privacy.org/ipc/) [![Blue Ribbon](images/ribbon.gif)](http://mirrors.yahoo.com/eff/blueribbon.html)

--- a/scripts/convert_external.py
+++ b/scripts/convert_external.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from html_to_md import MDConverter
+
+NAV = """
+[download](green/download/index.html)
+[download](gold/download/index.html)
+[history](history/index.html)
+[Related Sites](related.html)
+
+_[contact us](contact.html)_
+or [![](images/cmn.gif)](http://www.blindpay.com/crit-me-now.cgi)
+
+[![Golden Key](images/key.gif)](http://www.privacy.org/ipc/) [![Blue Ribbon](images/ribbon.gif)](http://mirrors.yahoo.com/eff/blueribbon.html)
+"""
+
+external_dir = 'external'
+md_dir = 'md'
+for fname in os.listdir(external_dir):
+    if not fname.endswith('.html'):
+        continue
+    path = os.path.join(external_dir, fname)
+    with open(path, 'r', encoding='utf8', errors='ignore') as f:
+        html = f.read()
+    parser = MDConverter()
+    parser.feed(html)
+    md = parser.get_md()
+    base = os.path.splitext(fname)[0]
+    outname = base.upper() + '.md' if base.lower() == 'faq' else base + '.md'
+    outpath = os.path.join(md_dir, outname)
+    with open(outpath, 'w', encoding='utf8') as f:
+        f.write(md)
+        f.write('\n\n')
+        f.write(NAV.strip())
+        f.write('\n')
+    print('wrote', outpath)

--- a/scripts/html_to_md.py
+++ b/scripts/html_to_md.py
@@ -1,0 +1,111 @@
+from html.parser import HTMLParser
+import sys
+
+class MDConverter(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.md = []
+        self.href_stack = []
+        self.list_depth = 0
+        self.in_pre = False
+        self.skip_pre = True
+        self.skip_content = False
+        self.in_head = False
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        if tag == "head":
+            self.in_head = True
+            return
+        if self.in_head:
+            return
+        if tag in ("h1","h2","h3","h4","h5","h6"):
+            level = int(tag[1])
+            self.md.append('\n' + '#' * level + ' ')
+        elif tag == "p":
+            self.md.append('\n\n')
+        elif tag == "br":
+            self.md.append('\n')
+        elif tag == "hr":
+            self.md.append('\n\n---\n\n')
+        elif tag == "b":
+            self.md.append('**')
+        elif tag == "i" or tag == "em":
+            self.md.append('*')
+        elif tag == "pre":
+            if self.skip_pre:
+                self.skip_pre = False
+                self.in_pre = False
+                self.skip_content = True
+            else:
+                self.in_pre = True
+                self.md.append('\n\n```\n')
+        elif tag == "img":
+            alt = ''
+            src = ''
+            for k,v in attrs:
+                if k.lower() == 'alt':
+                    alt = v
+                elif k.lower() == 'src':
+                    src = v
+            self.md.append(f'![{alt}]({src})')
+        elif tag == "a":
+            href = ''
+            for k,v in attrs:
+                if k.lower() == 'href':
+                    href = v
+            if href and not href.startswith('#'):
+                self.md.append('[')
+                self.href_stack.append(href)
+            else:
+                self.href_stack.append(None)
+        elif tag in ("ul","ol"):
+            self.list_depth += 1
+        elif tag == "li":
+            self.md.append('\n' + '  '* (self.list_depth-1) + '- ')
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag == "head":
+            self.in_head = False
+            return
+        if self.in_head:
+            return
+        if tag in ("b",):
+            self.md.append('**')
+        elif tag in ("i","em"):
+            self.md.append('*')
+        elif tag == "pre":
+            if self.skip_content:
+                self.skip_content = False
+            elif self.in_pre:
+                self.in_pre = False
+                self.md.append('\n```\n')
+        elif tag == "a":
+            href = self.href_stack.pop() if self.href_stack else None
+            if href:
+                self.md.append(f']({href})')
+        elif tag in ("ul","ol"):
+            if self.list_depth > 0:
+                self.list_depth -= 1
+
+    def handle_data(self, data):
+        if not self.skip_content and not self.in_head:
+            self.md.append(data)
+
+    def handle_entityref(self, name):
+        entity_map = {'nbsp': ' ', 'amp': '&', 'lt': '<', 'gt': '>'}
+        self.md.append(entity_map.get(name, ''))
+
+    def get_md(self):
+        text = ''.join(self.md)
+        return text.strip()
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        with open(path, 'r', encoding='utf8', errors='ignore') as f:
+            html = f.read()
+        parser = MDConverter()
+        parser.feed(html)
+        md = parser.get_md()
+        print(md)


### PR DESCRIPTION
## Summary
- add scripts to convert external HTML files
- convert external HTML pages into markdown under `md/`
- replace placeholder FAQ with real content

## Testing
- `npx prettier -w md/FAQ.md md/future.md md/ideal.md md/inforights.md md/transcopy.md`
- `node scripts/check-anchors.js`
- `npm run anchors` *(fails: linkinator missing)*