### PR TITLE
Update links to point to markdown anchors

### DIFF
--- a/md/future.md
+++ b/md/future.md
@@ -171,17 +171,20 @@ computers behave as a single entity using the Xanadu publication method.
 These are run by companies and individuals who choose to be service
 providers using the shared method.
 
-ALL MATERIAL IS ONE
+### All material is one
+
 All the contents on all of the Xanadu storage servers act as a
 single pool. You can send for any part of any document or link to or
 quote any part of any document.
 
-THE REQUESTS FAN OUT
+### The requests fan out
+
 Users ask for pieces of documents and objects. A request is
 received by the user's session node which fans it out to wherever the
 material is.
 
-AND THE PAYMENTS COME BACK
+### And the payments come back
+
 The user's payment is correspondingly sent to those publishers
 involved with the transaction.
 
@@ -203,13 +206,15 @@ according to their own preferences.
 
 ## Definition of terms
 
-HYPERTEXT
+### Hypertext
+
 The computer screen makes new forms of writing possible that are not
 sequential. "Hypertext," a term coined by us, mean non-sequential
 writing for the computer screen (our term "hypertext" is now in wide
 popular usage).
 
-HYPERMEDIA
+### Hypermedia
+
 "Hypermedia," another of our terms, extends the hypertext concept to
 sound, video and computer graphics. Multimedia presentations where the
 user may branch and explore have now become recognised as an exciting
@@ -218,13 +223,15 @@ Carmen Sandiego are among titles already popular in this area. CD-I and
 3DO are among the hardware players being fielded. Some use the term
 "interactive multimedia," but it is indeed the same thing as hypermedia.
 
-THE REPOSITORY NETWORK
+### The repository network
+
 We think the future goes far beyond hardware players and plastic
 disks. Tomorrow's publishing for computer screens will be principally
 over networks. Xanadu has been planned from the beginning as a network
 for delivery of copyrighted media to users on demand.
 
-AUTOMATIC ROYALTY
+### Automatic royalty
+
 Our copyright solution has always been for the user to pay a small
 royalty to the media publisher for every byte sent. Instead of buying
 whole documents, this allows the user continually to pick and choose on
@@ -233,7 +240,8 @@ typically not buy whole publications, but move and ramble unpredictably.
 The royalty is paid automatically at the instant of delivery, only and
 exactly for the portion sent.
 
-TRANSPUBLICATION
+### Transpublication
+
 This in turn means that any publisher in our system may quote any
 other publisher freely since the "quotation" is a pointer to the
 original publication. The user automatically sends for the quotation
@@ -249,7 +257,8 @@ original publisher and stays in the original publisher's storage space.
 And the original publisher gets the royalty on the portions which are
 transpublished.
 
-THE COPYRIGHT SOLUTION
+### The copyright solution
+
 For all participants within the Xanadu network, this cleans up the
 copyright issue:
 
@@ -271,7 +280,8 @@ We believe this will be the universal solution to the copyright issue in
 our time and that others operating in this computer multimedia area do
 not yet understand this.
 
-OPEN HYPERMEDIA PUBLISHING
+### Open hypermedia publishing
+
 We call the whole system of publication "open hypermedia publishing"
 because anyone can link to, and re-use, materials of any kind throughout
 the network. We believe that Xanadu Open Hypermedia Publishing is the

--- a/md/transcopy.md
+++ b/md/transcopy.md
@@ -1,11 +1,8 @@
-transcopy
+# Transcopyright
 
-( E36fix981014
+E36fix981014
 
-.html
-
- 
-[To Xanadu Australia Home Page](../index.html)
+[To Xanadu Australia Home Page](../index.md)
 
  
 
@@ -27,9 +24,10 @@ transcopy E36
 .html
 
 asof 95.4.9
-**Transcopyright:**
 
-**Pre-Permission for Virtual Republishing**
+## Transcopyright
+
+### Pre-Permission for Virtual Republishing
 
 **Theodor Holm Nelson**
 
@@ -41,7 +39,7 @@ asof 95.4.9
 
  
 
-**SUMMARY**
+## Summary
 
 The on-line copyright problem may be resolvable by a simple, sweeping
 permission method.  This proposed system, which anyone may use, allows
@@ -53,7 +51,7 @@ is immediately available), and users are not spied upon.
 A wording and an abbreviation for this permission system are proposed
 here.
 
-**INTRODUCTION**
+## Introduction
 
 Someone who asks, "How do we keep people from stealing food?" is asking
 you to consider only his side of the issue, without addressing underlying
@@ -90,7 +88,7 @@ history, and present it as a method anyone can use.  It is a legal
 permission doctrine with far-reaching consequences, whose benefits may
 be considerable.
 
-**THE OBJECTIVE**
+## The Objective
 
 From the beginning, the objective of Project Xanadu was to facilitate
 a new kind of literature: a new populist medium, a many-to-many publishing
@@ -128,7 +126,7 @@ copy of the materials, all purchased anew from the original publisher. 
 What may be just as important, it provides incentives for participation
 and a method for honest re-use in a system from which all benefit.
 
-**A PERMISSION DOCTRINE**
+## A Permission Doctrine
 
 What is proposed here turns out actually to be, at its center, a permission
 doctrine.  A new permission doctrine may be easily added to our culture;
@@ -146,7 +144,7 @@ This has a number of benefits: (1) the user knows the origin; (2) this
 identification can be part of a proof of purchase; (3) in principle, any
 recipient may republish in the same fashion, ad infinitum.
 
-LONG FORM PERMISSION
+## Long Form Permission
 
 To allow this, the copyright holder must therefore make a statement
 like the following.  (Note that I am still tinkering with the provisions
@@ -161,7 +159,7 @@ address for bytes to be included in a particular new context; and provided
 This may be adequate to achieve the desired result, as we will consider
 below.  It also leaves room for a number of possible variations.
 
-**IRONICALLY SIMPLE**
+## Ironically Simple
 
 This may seem over-simple, when mighty technical and legislative solutions
 are being sought by so many parties.  But it shifts the ground of
@@ -179,7 +177,7 @@ benefit.  More traditional publishers and authors may hesitate, not
 recognizing that all the traditional objectives may be satisfied by this
 system.
 
-**IMPLIED ASPECTS**
+## Implied Aspects
 
 Implied in this method are certain other aspects of implementation. 
 For instance, the user must be given a receipt for each portion purchased,
@@ -190,7 +188,7 @@ possible once again (by the new recipient).  And the republisher must
 notify the original publisher of the republication, so that these re-uses
 may be seen.
 
-**SUPPORTING SOFTWARE ASPECTS**
+## Supporting Software Aspects
 
 This permission doctrine has certain minimal requirements for supporting
 software.  Certain unusual software features are required:
@@ -217,14 +215,14 @@ program (or feature) must then prepare the document for skeleton transmission,
 stripping out the actual bytes and substituting the original addresses
 in the necessary format for their repurchase.
 
-**OWNERSHIP OF EACH FINAL COPY**
+## Ownership of Each Final Copy
 
 The recipient who purchases the suggested materials owns a final copy,
 like any book, each portion legally purchased.  Even if the materials
 are later withdrawn from sale, each copy already acquired in this way retains
 itsownership status as the possession of the recipient.
 
-**COMPATIBILITY, INTEROPERABILITY**
+## Compatibility, Interoperability
 
 Note that any party may offer transcopyright; and note that different
 variations of this arrangement, with different details of availability,
@@ -232,7 +230,7 @@ may be mixed and matched in a given document (see below).  Regardless
 of such variations, a legitimate mixed copy is still owned by the final
 recipient.
 
-**THE PROPOSED FORMAT AND ITS LEGAL STATUS**
+## The Proposed Format and Its Legal Status
 
 I propound for this permission system an extremely simple presentational
 format. A publisher signifies participation by the following notice, in
@@ -281,9 +279,9 @@ widely accepted and used.  If others use the transcopyright notification
 with the intent given here, it will be recognized in law (like shareware
 and copyleft) as being synonymous with the longer permission notice.
 
-**VARIATIONS NOT COVERED;**
+## Variations Not Covered
 
-**DIFFERENT JURISDICTIONS**
+## Different Jurisdictions
 
 This arrangement is for on-line screen viewing and keepage of digital
 data, not for paper or other solid media.
@@ -304,7 +302,7 @@ own systems.  (For instance, the contracts of Project Xanadu will
 have specific clauses with respect to length of availability, paper printout
 and site licensing.)
 
-**ENFORCEMENT AND BENEFITS**
+## Enforcement and Benefits
 
 This system is not automatically enforced, but neither is any other
 feasible electronic copyright system.  It is no more or less enforceable
@@ -319,14 +317,14 @@ a strong argument in its favor.
 
 ---
 
-**ACKNOWLEDGMENT**
+## Acknowledgment
 
 My especial thanks to Robert W. Fiddler, Esq., of Great Neck, N.Y. for
 over twenty-five years of friendship, generous legal tutoring and delightful
 banter that have helped shape these ideas; but any errors, misunderstandings
 or improprieties are my own.
 
-**BIBLIOGRAPHY**
+## Bibliography
 
 1.   Nelson, Theodor Holm, _Literary Machines_. 
 Availabile from Mindful Press, 3020 Bridgeway #295, Sausalito CA 94965,

--- a/specs/dictionary.md
+++ b/specs/dictionary.md
@@ -4,11 +4,11 @@
 
 An account is the system's representation of a user. The account includes that
 users' [documents](#document). Users can have multiple accounts.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## Be
 
-Short for [backend](#backend). ([source](green/febe/glossary.html))
+Short for [backend](#backend). ([source](../md/green/febe/glossary.md))
 
 ## backend
 
@@ -16,19 +16,19 @@ One of two high-level modules required for a Udanax Green hypertext system. The
 backend is responsible for document and version storage, link management and
 editing. In many installations it will run on a more powerful computer networked
 to the individual workstation where users work. (See [frontend](#frontend).)
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## data-byte
 
 The smallest addressable unit of storage in the Udanax Green FeBe Protocol. A
 data-byte is an eight bit unsigned binary number.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## data space
 
 The part of a [document](#document) that contains arbitrary data, supplied by
 the user or front-ends. The other space in [documents](#document) is the
-[link space](#linkslink-space). ([source](green/febe/glossary.html))
+[link space](#linkslink-space). ([source](../md/green/febe/glossary.md))
 
 ## document
 
@@ -37,12 +37,12 @@ thematically unified. Such documents resemble contemporary paper documents
 except that clips of animation, pictures, and sound tracks may also be
 documents. Also, in fully integrated hypermedia systems, the typical document
 will likely be smaller in size - closer to the length of an article in a
-newspaper than to the length of a book. ([source](green/febe/glossary.html))
+newspaper than to the length of a book. ([source](../md/green/febe/glossary.md))
 
 ## docuverse
 
 The abstract address space that contains all Udanax Green objects.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## end-set
 
@@ -51,23 +51,23 @@ The sets that describe links. Each link has three end-sets: a
 three end-sets are operationally the same, but by convention, links start at the
 [from-set](#from-set) and end at the [to-set](#to-set), and have a type as
 defined by their [three-set](#three-set). Each link also has a
-[home-set](#home-set). ([source](green/febe/glossary.html))
+[home-set](#home-set). ([source](../md/green/febe/glossary.md))
 
 ## Fe
 
-Short for [frontend](#frontend). ([source](green/febe/glossary.html))
+Short for [frontend](#frontend). ([source](../md/green/febe/glossary.md))
 
 ## FeBe Protocol
 
 [Frontends](#frontend) communicate with the [backend](#backend) using a
 standard, public protocol called FeBe (stands for &quot;Frontend Backend&quot;).
 Other sections of this package describe the preliminary protocol used by the
-current system. ([source](green/febe/glossary.html))
+current system. ([source](../md/green/febe/glossary.md))
 
 ## from-set
 
 The set of elements from which a link `starts'. (See [end-set](#end-set).)
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## frontend
 
@@ -75,41 +75,41 @@ One of the two high-level modules required for a multi-user Udanax Green
 hypertext system. The frontend is responsible for presenting the information
 from [the backend](#backend) to the user on his or hers workstation. (See
 [backend](#backend).) It supports users in reading, creating, and editing
-information. ([source](green/febe/glossary.html))
+information. ([source](../md/green/febe/glossary.md))
 
 ## home-set
 
 The set of [documents](#document) that actually contain a given link in their
 contents. Note that the home of a [document](#document) is independent from any
-of its [end-sets](#end-set). ([source](green/febe/glossary.html))
+of its [end-sets](#end-set). ([source](../md/green/febe/glossary.md))
 
 ## hypertext
 
 Any form of non-linear writing. This includes paper mechanisms such as table of
 contents and indexes. Computerized hypertext allows readers to navigate through
-large quantities of information. ([source](green/febe/glossary.html))
+large quantities of information. ([source](../md/green/febe/glossary.md))
 
 ## hypermedia
 
 Everything that [hypertext](#hypertext) does, but NOW IMPROVED! NOW WITH
-PICTURES, ANIMATION, AND SOUND! ([source](green/febe/glossary.html))
+PICTURES, ANIMATION, AND SOUND! ([source](../md/green/febe/glossary.md))
 
 ## ID
 
 A global [tumbler](#tumbler) address of [a document](#document), link,
 [data-byte](#data-byte), etc. The ordering of the addresses groups related
 things. For example, the [documents](#document) of a single user have contiguous
-addresses. ([source](green/febe/glossary.html))
+addresses. ([source](../md/green/febe/glossary.md))
 
 ## links:link space
 
 The part of a [document](#document) in which links reside. The other space is
-the [data space](#data-space). ([source](green/febe/glossary.html))
+the [data space](#data-space). ([source](../md/green/febe/glossary.md))
 
 ## node
 
 A running Udanax Green [backend](#backend), and all information it contains.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## span
 
@@ -119,7 +119,7 @@ An span specifies a range of [tumblers](#tumbler) with a starting
 exclusive. (See the chapter &quot;Tumbler Arithmetic&quot;.) Because of the
 uniformity of addressing, spans can represent ranges of
 [data-bytes](#data-byte), links, [documents](#document), and even users.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## spec
 
@@ -127,17 +127,17 @@ Many of the FeBe operations use a set of specs to specify a set of arbitrary
 Udanax Green objects. A spec is either a [span](#span) of globally addressed
 elements like [documents](#document), or a [document identifier](#document) and
 a set of [vspans](#vspan) (document local spans).
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## three-set
 
 The [end-set](#end-set) which determines the type of a link, by convention.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## to-set
 
 The [end-set](#end-set) which a link points to, by convention.
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## tumbler
 
@@ -147,7 +147,7 @@ at any point, a numbering system based on them never runs out of precision.
 Udanax Green uses tumblers for all address to allow any number of
 [nodes](#node), users, [documents](#document), [data-bytes](#data-byte), and
 links. (See the chapters &quot;Addressing&quot; and &quot;Tumbler
-Arithmetic&quot;.) ([source](green/febe/glossary.html))
+Arithmetic&quot;.) ([source](../md/green/febe/glossary.md))
 
 ## vspan
 
@@ -157,55 +157,82 @@ Like a [span](#span), a vspan has a start and [width](#width)
 however. The vspan designates everything between the start tumbler inclusive and
 the start plus the width exclusive. The width can cross the boundaries of space
 within the [document](#document). (See the chapter &quot;Addressing&quot;.)
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## width
 
 The size of a [span](#span); the sum of the origin [tumbler](#tumbler) and width
 [tumbler](#tumbler) is the first thing past the end of the [span](#span).
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## Udanax Green
 
 A [hypertext](#hypertext) [backend](#backend) designed to allow multiple
 concurrent users to have fast retrieval and update of hypertext information
-pools of unbounded size. ([source](green/febe/glossary.html))
+pools of unbounded size. ([source](../md/green/febe/glossary.md))
 
 ## Udanax Green:Udanax Green objects
 
 [Nodes](#node), [accounts](#account), [documents](#document), links, and
 [data-bytes](#data-byte) are all objects in the Udanax Green address space (also
 called &quot;the [docuverse](#docuverse)&quot;).
-([source](green/febe/glossary.html))
+([source](../md/green/febe/glossary.md))
 
 ## canopy
 
 A balanced binary tree structure of CanopyCrums used in Udanax Gold to propagate
-property changes and manage recorders. ([source](history/index.html))
+property changes and manage recorders. ([source](../md/history/index.md))
 
 ## detector
 
 An object clients register to receive callbacks when editions or range elements
-change, such as when placeholders are filled. ([source](history/index.html))
+change, such as when placeholders are filled. ([source](../md/history/index.md))
 
 ## coordinate space system
 
 A general framework defining positions, regions, mappings, and order
 specifications that describe the domain of tables.
-([source](gold/download/index.html))
+([source](../md/gold/download/index.md))
 
 ## enfilade
 
 The tree-based data structure underlying Xanadu storage, allowing efficient
 versioned documents and [transclusion](#transclusion).
-([source](history/index.html))
+([source](../md/history/index.md))
 
 ## The Ent
 
 A more advanced implementation of [enfilade](#enfilade) concepts developed for
-Udanax Gold. ([source](gold/index.html))
+Udanax Gold. ([source](../md/gold/index.md))
 
 ## transclusion
 
 The reuse of content by reference to its original location so the same material
-can appear in many contexts without duplication. ([source](green/index.html))
+can appear in many contexts without duplication. ([source](../md/green/index.md))
+
+## FAQ
+
+A compilation of "Frequently Asked Questions" about the Xanadu Project that
+collects answers for new readers. ([source](../md/FAQ.md#1-what-is-xanadu))
+
+## The Information Future
+
+An overview of Xanadu's vision for the future of
+[hypermedia](#hypermedia) publishing and how authors, readers and
+publishers might interact. ([source](../md/future.md#transpublication))
+
+## The Xanadu Ideal
+
+Ted Nelson's statement of principles describing how Xanadu differs from other
+[hypertext](#hypertext) systems. ([source](../md/ideal.md#why-do-they-call-us-a-cult))
+
+## Inforights
+
+Also known as the "Bill of Information Rights," this text proposes a framework
+for open [hypermedia](#hypermedia) publishing through contractual
+agreements. ([source](../md/inforights.md#bill-of-information-rights))
+
+## transcopyright
+
+A permission system proposed by Ted Nelson that allows republication of digital
+materials while tracking ownership and crediting authors. ([source](../md/transcopy.md#summary))


### PR DESCRIPTION
## Summary
- switch dictionary references from HTML to Markdown files with section anchors
- convert section titles in `future.md` to proper headings
- add headings to `transcopy.md` so anchors can be targeted

## Testing
- `npm run ok`
